### PR TITLE
Add history command

### DIFF
--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/ActionFilters.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/ActionFilters.kt
@@ -1,11 +1,45 @@
 package net.ddns.mindustry.database.plugin
 
+import arc.Core
+import arc.math.geom.Point2
+import arc.util.I18NBundle
+import arc.util.Log
 import mindustry.Vars.netServer
+import mindustry.content.Blocks
+import mindustry.ctype.UnlockableContent
+import mindustry.gen.Building
 import mindustry.net.Administration
+import mindustry.net.Administration.ActionType
+import mindustry.world.Block
+import mindustry.world.blocks.ConstructBlock
 import net.ddns.mindustry.database.plugin.Main.Companion.database
+import net.ddns.mindustry.database.plugin.configs.PluginConfigs.Configs.configTileHistoryLimit
+
+private val recordedActions = setOf(
+    ActionType.placeBlock,
+    ActionType.breakBlock,
+    ActionType.configure,
+    ActionType.rotate,
+)
+
+// The server didn't retrieve the bundle, so I fetched it manually
+private val contentBundle: I18NBundle? by lazy {
+    try {
+        I18NBundle.createBundle(Core.files.internal("bundles/bundle"))
+    } catch (e: Throwable) {
+        Log.err("Tile-history: couldn't load locale bundle, falling back to internal block ids.", e)
+        null
+    }
+}
+
+private fun localizedName(content: UnlockableContent): String =
+    contentBundle?.get("${content.contentType.name}.${content.name}.name", content.localizedName)
+        ?: content.localizedName
 
 fun loadActionFilters() {
+    TileHistoryStore.capacity = configTileHistoryLimit.num()
     netServer.admins.actionFilters.add(Administration.ActionFilter(::noBanned))
+    netServer.admins.actionFilters.add(Administration.ActionFilter(::recordTileHistory))
 }
 
 // literally 1984...
@@ -20,4 +54,69 @@ private fun noBanned(action: Administration.PlayerAction): Boolean {
     }
 
     return true
+}
+
+private fun recordTileHistory(action: Administration.PlayerAction): Boolean {
+    if (action.type !in recordedActions || action.tile == null) {
+        return true
+    }
+
+    val account = database?.account()?.find(action.player.ip(), action.player.uuid())
+    if (account == null || account.isEmpty) {
+        return true
+    }
+
+    val build = action.tile.build
+    val block = resolveRealBlock(action.block ?: build?.block ?: action.tile.block(), build)
+    val size = block?.size ?: 1
+    // A placed block's origin is its bottom-left tile: an existing building exposes it directly,
+    // otherwise the clicked (centre) tile is shifted by the block's size offset.
+    val originX = if (build != null) build.tile.x.toInt() else action.tile.x + (block?.sizeOffset ?: 0)
+    val originY = if (build != null) build.tile.y.toInt() else action.tile.y + (block?.sizeOffset ?: 0)
+
+    TileHistoryStore.record(
+        TileEvent(
+            actorName = account.get().username(),
+            accountId = account.get().id(),
+            coord = Point2.pack(originX, originY),
+            coords = footprintCoords(originX, originY, size),
+            action = action.type,
+            blockName = block?.let { localizedName(it) },
+            configSummary = if (action.type == ActionType.configure) summarizeConfig(action.config) else null,
+            rotation = action.rotation,
+            epochMillis = System.currentTimeMillis(),
+        )
+    )
+
+    return true
+}
+
+// While a block is deconstructing, the tile holds a ConstructBlock placeholder ("build<size>").
+// Resolve it back to the real block so streamed actions report the correct name.
+private fun resolveRealBlock(block: Block?, build: Building?): Block? {
+    if (block !is ConstructBlock) return block
+    val construct = build as? ConstructBlock.ConstructBuild ?: return block
+    return sequenceOf(construct.current, construct.previous)
+        .firstOrNull { it != null && it != Blocks.air && it !is ConstructBlock } ?: block
+}
+
+private fun footprintCoords(originX: Int, originY: Int, size: Int): IntArray {
+    val coords = IntArray(size * size)
+    var i = 0
+    for (dx in 0 until size) {
+        for (dy in 0 until size) {
+            coords[i++] = Point2.pack(originX + dx, originY + dy)
+        }
+    }
+    return coords
+}
+
+private fun summarizeConfig(config: Any?): String? = when (config) {
+    null -> null
+    is Boolean -> if (config) "on" else "off"
+    is UnlockableContent -> localizedName(config)
+    is Int -> if (config == -1) "disconnected" else "linked to (${Point2.x(config)}, ${Point2.y(config)})"
+    is IntArray -> if (config.isEmpty()) "no links" else "${config.size} links"
+    is Array<*> -> if (config.isEmpty()) "no links" else "${config.size} links"
+    else -> config.toString()
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/EventReceivers.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/EventReceivers.kt
@@ -7,6 +7,8 @@ import mindustry.game.EventType.PlayerConnect
 import mindustry.game.EventType.PlayerLeave
 import mindustry.game.EventType.PlayEvent
 import mindustry.game.EventType.StateChangeEvent
+import mindustry.game.EventType.TapEvent
+import mindustry.game.EventType.WorldLoadEvent
 import mindustry.game.Team
 import mindustry.gen.Call
 import mindustry.gen.Player
@@ -16,6 +18,7 @@ import net.ddns.mindustry.database.client.PunishmentListener
 import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.client.ServerAccountQueries
 import net.ddns.mindustry.database.plugin.Main.Companion.database
+import net.ddns.mindustry.database.plugin.commands.client.unprivileged.History
 import net.ddns.mindustry.database.plugin.configs.PluginConfigs.Configs.configServerIP
 import net.ddns.mindustry.database.plugin.events.PlayerLogin
 import net.ddns.mindustry.database.schema.enums.PunishmentType
@@ -30,6 +33,17 @@ fun loadMindustryEvents() {
     Events.on(PlayerLeave::class.java) {e -> playerLeave(e)}
     Events.on(PlayEvent::class.java) {_ -> startHeartbeatScheduler()}
     Events.on(StateChangeEvent::class.java) {e -> gameOver(e)}
+
+    Events.on(TapEvent::class.java) {e -> tileTapped(e)}
+    Events.on(WorldLoadEvent::class.java) {_ -> TileHistoryStore.clear()}
+}
+
+private fun tileTapped(event: TapEvent) {
+    if (event.tile == null || !History.inspecting.contains(event.player.uuid())) {
+        return
+    }
+
+    event.player.sendMessage(renderTileHistory(event.tile.x.toInt(), event.tile.y.toInt()))
 }
 
 fun loadDatabaseEvents() {

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/TileHistory.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/TileHistory.kt
@@ -1,0 +1,112 @@
+package net.ddns.mindustry.database.plugin
+
+import arc.math.geom.Point2
+import mindustry.net.Administration.ActionType
+
+data class TileEvent(
+    val actorName: String,
+    val accountId: Int,
+    // The block's bottom-left origin tile
+    val coord: Int,
+    // Every tile the block covers (packed), so a lookup on any covered tile finds this event.
+    val coords: IntArray,
+    val action: ActionType,
+    val blockName: String?,
+    val configSummary: String?,
+    val rotation: Int,
+    val epochMillis: Long,
+)
+
+/**
+ * In-memory log of player tile actions, with a configurable capacity.
+ */
+object TileHistoryStore {
+    private val events = ArrayDeque<TileEvent>()
+
+    // Last signature to prevent recording duplicate consecutive events
+    private val lastSignature = HashMap<Int, String>()
+
+    var capacity = 10_000
+
+    fun record(event: TileEvent) {
+        val signature = signatureOf(event)
+        if (lastSignature[event.coord] == signature) {
+            return
+        }
+        lastSignature[event.coord] = signature
+
+        events.addLast(event)
+        while (events.size > capacity) {
+            events.removeFirst()
+        }
+    }
+
+    fun get(coord: Int): List<TileEvent> = events.filter { coord in it.coords }
+
+    fun getByActor(name: String): List<TileEvent> =
+        events.filter { it.actorName.equals(name, ignoreCase = true) }
+
+    fun clear() {
+        events.clear()
+        lastSignature.clear()
+    }
+
+    private fun signatureOf(event: TileEvent) =
+        "${event.action}|${event.blockName}|${event.configSummary}|${event.rotation}|${event.accountId}"
+}
+
+fun renderTileHistory(x: Int, y: Int): String {
+    val history = TileHistoryStore.get(Point2.pack(x, y))
+
+    if (history.isEmpty()) {
+        return "[accent]No history for ($x, $y)."
+    }
+
+    val builder = StringBuilder("[accent]History for ($x, $y):[]")
+    for (event in history) {
+        builder.append("\n  [white]").append(event.actorName).append("[white] ").append(describe(event))
+            .append(" — ").append(relativeTime(event.epochMillis))
+    }
+    return builder.toString()
+}
+
+fun renderPlayerHistory(name: String): String {
+    val history = TileHistoryStore.getByActor(name)
+
+    if (history.isEmpty()) {
+        return "[accent]No history for [white]$name[accent]."
+    }
+
+    val shown = history.takeLast(50)
+    val builder = StringBuilder("[accent]History for [white]$name[accent]:[]")
+    if (history.size > shown.size) {
+        builder.append("\n  [gray]… ${history.size - shown.size} older entries not shown")
+    }
+    for (event in shown) {
+        builder.append("\n  ").append(describe(event))
+            .append(" at (${Point2.x(event.coord)}, ${Point2.y(event.coord)})")
+            .append("[white] — ").append(relativeTime(event.epochMillis))
+    }
+    return builder.toString()
+}
+
+private fun describe(event: TileEvent): String {
+    val block = event.blockName ?: "block"
+    return when (event.action) {
+        ActionType.placeBlock -> "[green]placed[] $block"
+        ActionType.breakBlock -> "[scarlet]broke[] $block"
+        ActionType.rotate -> "[sky]rotated[] $block"
+        ActionType.configure -> "[orange]configured[] $block" + (event.configSummary?.let { " to $it" } ?: "")
+        else -> "[lightgray]${event.action.name}[] $block"
+    }
+}
+
+private fun relativeTime(epochMillis: Long): String {
+    val seconds = (System.currentTimeMillis() - epochMillis) / 1000
+    return when {
+        seconds < 60 -> "${seconds}s ago"
+        seconds < 3600 -> "${seconds / 60}m ago"
+        seconds < 86400 -> "${seconds / 3600}h ago"
+        else -> "${seconds / 86400}d ago"
+    }
+}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/unprivileged/History.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/unprivileged/History.kt
@@ -1,0 +1,61 @@
+package net.ddns.mindustry.database.plugin.commands.client.unprivileged
+
+import arc.util.CommandHandler
+import mindustry.Vars
+import mindustry.gen.Player
+import net.ddns.mindustry.database.plugin.renderPlayerHistory
+import net.ddns.mindustry.database.plugin.renderTileHistory
+
+/**
+ * Lets any player inspect what changed and by whom.
+ * No arguments : toggles a tap-to-inspect mode for player
+ * `<player>` : prints that player's recent actions
+ * `<x> <y>` : prints the history of that tile.
+ * History is in-memory and resets when the map changes.
+ * Made available to everyone so players can identify and votekick griefers.
+ */
+class History(handler: CommandHandler) : UnprivilegedClientCommand(handler) {
+    companion object {
+        val inspecting: MutableSet<String> = mutableSetOf()
+
+        init {
+            description = "Inspect who changed a tile or what a player did. " +
+                    "[lightgray](in-memory, resets on map change)[]\n" +
+                    "  [accent]/history[white] - toggle tap-to-inspect, then tap a tile\n" +
+                    "  [accent]/history <player>[white] - that player's recent actions\n" +
+                    "  [accent]/history <x> <y>[white] - history of a single tile"
+            parameters = "[player/x] [y]"
+        }
+    }
+
+    override fun runner(arguments: Array<String>, player: Player) {
+        when (arguments.size) {
+            0 -> toggleInspect(player)
+            1 -> player.sendMessage(renderPlayerHistory(arguments[0]))
+            2 -> showTile(arguments[0], arguments[1], player)
+            else -> player.sendMessage("[scarlet]Usage: /history, /history <player>, or /history <x> <y>")
+        }
+    }
+
+    private fun showTile(xArg: String, yArg: String, player: Player) {
+        val x = xArg.toIntOrNull()
+        val y = yArg.toIntOrNull()
+        val tile = if (x == null || y == null) null else Vars.world.tile(x, y)
+
+        if (tile == null) {
+            player.sendMessage("[scarlet]Those coordinates are not on the map.")
+            return
+        }
+
+        player.sendMessage(renderTileHistory(tile.x.toInt(), tile.y.toInt()))
+    }
+
+    private fun toggleInspect(player: Player) {
+        if (inspecting.remove(player.uuid())) {
+            player.sendMessage("[accent]Tile-history inspector [scarlet]off[accent].")
+        } else {
+            inspecting.add(player.uuid())
+            player.sendMessage("[accent]Tile-history inspector [green]on[accent]. Tap a tile to view its history.")
+        }
+    }
+}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/configs/PluginConfigs.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/configs/PluginConfigs.kt
@@ -23,6 +23,9 @@ class PluginConfigs : ReloadableConfig() {
         val configCommandAttempts = Config("command-attempts", "The number of attempts that are" +
                 " recorded for the rate limit.", 5)
 
+        val configTileHistoryLimit = Config("tile-history-limit", "The maximum number of tile" +
+                " actions kept in the in-memory history before the oldest are discarded.", 10000)
+
 //        val configRoleConfigPath = Config(
 //            "roles-config-path", "The path to the configuration file for roles.",
 //            "config/mindustry_database/roles_config.yaml"


### PR DESCRIPTION
ActionFilters: On user action store it in TileHistory
Also lazy load locale bundle manually (couldn't get the server to load it from the folder for some reason)
EventReceivers: Fetch user clicks for history click mode
TileHistory: Store tile history up to a maximum capacity, render tile history
History: Handle the /history command
PluginConfigs: Allow maximum tile history capacity to be changed
