### PR TITLE
Temporary in-game IDs + interactive player picker

### DIFF
--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerName.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerName.kt
@@ -2,23 +2,36 @@ package net.ddns.mindustry.database.plugin
 
 import arc.util.Log
 import mindustry.gen.Player
+import kotlin.random.Random
 
 /**
  * Stores a player's displayed name.
  *
- * A player's name is composed from three independent inputs:
+ * A player's name is composed from four independent inputs:
+ *   - [State.id]     a temp two-character id assigned on connect, shown as an `[id]` prefix. A display handle so
+ * staff can tell players apart at a glance; it is not typed into commands (the interactive picker covers that).
  *   - [State.base]   the player's real chosen name, captured once on connect.
  *   - [State.tag]    an optional role symbol, shown as a `<symbol>` prefix.
  *   - [State.hidden] whether the name is hidden (unauthenticated or banned).
  */
 object PlayerName {
 
-    private data class State(val base: String, var tag: String? = null, var hidden: Boolean = false)
+    private const val ID_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+    private const val ID_LENGTH = 2
+
+    private data class State(val id: String, val base: String, var tag: String? = null, var hidden: Boolean = false)
 
     private val states: MutableMap<String, State> = mutableMapOf()
 
+    private val idIndex: MutableMap<String, String> = mutableMapOf()
+
     fun capture(player: Player) {
-        states.getOrPut(player.uuid()) { State(player.coloredName()) }
+        val uuid = player.uuid()
+        if (states.containsKey(uuid)) return
+
+        val id = allocateId()
+        states[uuid] = State(id, player.coloredName())
+        idIndex[id] = uuid
     }
 
     fun setTag(player: Player, symbol: String?) {
@@ -42,7 +55,8 @@ object PlayerName {
     fun isHidden(player: Player): Boolean = states[player.uuid()]?.hidden ?: false
 
     fun forget(player: Player) {
-        states.remove(player.uuid())
+        val state = states.remove(player.uuid()) ?: return
+        idIndex.remove(state.id)
     }
 
     private fun state(player: Player): State? {
@@ -54,12 +68,35 @@ object PlayerName {
     }
 
     private fun render(player: Player, state: State) {
-        player.name(
-            when {
-                state.hidden -> ""
-                state.tag != null -> "[accent]<[white]${state.tag}[accent]>[white] ${state.base}"
-                else -> state.base
-            }
-        )
+        if (state.hidden) {
+            player.name("")
+            return
+        }
+
+        val idPrefix = "[white][[${state.id}][]"
+        val body = if (state.tag != null) "[accent]<[white]${state.tag}[accent]>[white] ${state.base}"
+                   else state.base
+        player.name("$idPrefix$body")
     }
+
+    private fun allocateId(): String {
+        repeat(64) {
+            val candidate = randomId()
+            if (!idIndex.containsKey(candidate)) return candidate
+        }
+
+        // Fallback: a server would need 1296 concurrent players to reach this.
+        for (first in ID_ALPHABET) {
+            for (second in ID_ALPHABET) {
+                val candidate = "$first$second"
+                if (!idIndex.containsKey(candidate)) return candidate
+            }
+        }
+
+        Log.warn("Ran out of in-game ids; reusing a random one. This should never happen.")
+        return randomId()
+    }
+
+    private fun randomId(): String =
+        buildString { repeat(ID_LENGTH) { append(ID_ALPHABET[Random.nextInt(ID_ALPHABET.length)]) } }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerReference.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerReference.kt
@@ -1,0 +1,19 @@
+package net.ddns.mindustry.database.plugin
+
+import mindustry.gen.Player
+import net.ddns.mindustry.database.plugin.Main.Companion.database
+import net.ddns.mindustry.database.schema.tables.pojos.Account
+
+/**
+ * Looks up the [Account] a command argument refers to by its account name ([login]).
+ *
+ * This works for offline players
+ */
+fun resolveTargetAccount(login: String, sender: Player): Account? {
+    val account = database!!.account().find(login)
+    if (account.isEmpty) {
+        sender.sendMessage("[scarlet]Couldn't find an account named \"$login\".")
+        return null
+    }
+    return account.get()
+}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerSelect.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerSelect.kt
@@ -29,9 +29,7 @@ object PlayerSelect {
 
         val options = targets.map { arrayOf(it.coloredName()) }.toTypedArray()
 
-        lateinit var menu: BaseMenu
-        menu = menuHandler.addMenu(title, message, options, callback@ { _: Player, child: Child ->
-            menuHandler.removeChild(menu.id)
+        val menu = menuHandler.addMenu(title, message, options, callback@ { _: Player, child: Child ->
             if (child !is BaseMenu) return@callback
             val picked = targets.getOrNull(child.option) ?: return@callback
 

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerSelect.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/PlayerSelect.kt
@@ -1,0 +1,48 @@
+package net.ddns.mindustry.database.plugin
+
+import mindustry.gen.Groups
+import mindustry.gen.Player
+import net.ddns.mindustry.database.plugin.Main.Companion.database
+import net.ddns.mindustry.database.schema.tables.pojos.Account
+import net.ddns.mindustry.segment.menuHandler
+import net.ddns.mindustry.segment.ui.Child
+import net.ddns.mindustry.segment.ui.menu.BaseMenu
+
+/**
+ * A "pick an online player" menu. Only players with a visible name are listed, and [onPick] receives the selected
+ * player's resolved [Account] (every caller wants the account, so the lookup lives here).
+ */
+object PlayerSelect {
+
+    fun open(
+        staff: Player,
+        title: String = "[gold]Select a player",
+        message: String = "Choose a player.",
+        filter: (Player) -> Boolean = { it.plainName().isNotEmpty() },
+        onPick: (Account) -> Unit,
+    ) {
+        val targets = buildList { Groups.player.forEach { if (filter(it)) add(it) } }
+        if (targets.isEmpty()) {
+            staff.sendMessage("[scarlet]No matching players are online.")
+            return
+        }
+
+        val options = targets.map { arrayOf(it.coloredName()) }.toTypedArray()
+
+        lateinit var menu: BaseMenu
+        menu = menuHandler.addMenu(title, message, options, callback@ { _: Player, child: Child ->
+            menuHandler.removeChild(menu.id)
+            if (child !is BaseMenu) return@callback
+            val picked = targets.getOrNull(child.option) ?: return@callback
+
+            val account = database!!.account().find(picked.ip(), picked.uuid())
+            if (account.isEmpty) {
+                staff.sendMessage("[scarlet]${picked.plainName()} isn't logged in, so they have no account.")
+                return@callback
+            }
+            onPick(account.get())
+        }, false)
+
+        menu.show(staff.con())
+    }
+}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/Utilities.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/Utilities.kt
@@ -5,15 +5,18 @@ import arc.util.Log
 import mindustry.Vars
 import mindustry.gen.Groups
 import mindustry.gen.Player
+import mindustry.net.Administration
 import net.ddns.mindustry.database.client.Database
 import net.ddns.mindustry.database.client.SecurityConfig
 import net.ddns.mindustry.database.plugin.Main.Companion.database
 import net.ddns.mindustry.database.plugin.commands.BaseCommand
 import net.ddns.mindustry.database.plugin.configs.PluginConfigs.Configs.configAccountLimit
+import net.ddns.mindustry.database.plugin.configs.PluginConfigs.Configs.configServerIP
 import net.ddns.mindustry.database.plugin.configs.ReloadableConfig.Configs.reloadConfigs
 import net.ddns.mindustry.database.plugin.configs.toml.databaseInfo
 import net.ddns.mindustry.database.schema.tables.pojos.Account
 import net.ddns.mindustry.database.schema.tables.pojos.Ban
+import net.ddns.mindustry.database.schema.tables.pojos.Server
 import java.security.NoSuchAlgorithmException
 import java.time.format.DateTimeFormatter
 import kotlin.reflect.KClass
@@ -81,6 +84,10 @@ fun registerCommands(commandList: List<KClass<out BaseCommand>>, handler: Comman
         command.primaryConstructor!!.call(handler)
     }
 }
+
+/** The server this plugin instance is registered as, resolved from the configured IP and port. */
+fun currentServer(): Server =
+    database!!.server().find(configServerIP.string(), Administration.Config.port.num()).get()
 
 fun findOnlinePlayer(username: String): Player? {
     val result = Groups.player.find {player -> comparePlayer(username, player)}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Ban.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Ban.kt
@@ -2,10 +2,11 @@ package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
 import mindustry.gen.Player
-import mindustry.net.Administration
 import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.database.plugin.configs.PluginConfigs
+import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
+import net.ddns.mindustry.database.plugin.currentServer
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
@@ -15,8 +16,8 @@ class Ban(handler: CommandHandler) : PrivilegedClientCommand(handler) {
         val banPermission: Permission
 
         init {
-            description = "Bans an account via its username. Display names and usernames are separate."
-            parameters = "<account-name> <duration> <reason...>"
+            description = "Bans a player by account name, or run with no arguments to pick an online player from a menu."
+            parameters = "[account-name] [duration] [reason...]"
 
             database!!.role().newPermission("ban")
             banPermission = database!!.role().findPermission("ban").get()
@@ -25,22 +26,24 @@ class Ban(handler: CommandHandler) : PrivilegedClientCommand(handler) {
 
     override fun runner(arguments: Array<String>, player: Player) {
         val issuerAccount = hasPermission(banPermission, player) ?: return
-        val issuer = Issuer.Player(issuerAccount)
 
-        val targetName = arguments[0]
-        val durationString = arguments[1]
-        val reason = arguments[2]
-
-        val target = database!!.account().find(targetName)
-        val duration = Duration.parse(durationString)
-        val server = database!!.server().find(PluginConfigs.configServerIP.string(), Administration.Config.port.num())
-
-        if (target.isEmpty) {
-            player.sendMessage("[scarlet]Couldn't find that player!")
+        if (arguments.isEmpty()) {
+            PunishFlow.start(player, "ban")
+            return
+        }
+        if (arguments.size < 3) {
+            player.sendMessage("[scarlet]Usage: /ban <account-name> <duration> <reason...>  (or /ban with no arguments to pick from a menu)")
             return
         }
 
-        database!!.punishment().ban(target.get(), issuer, reason, server.get(), duration.toJavaDuration())
-        player.sendMessage("$targetName was banned.")
+        val issuer = Issuer.Player(issuerAccount)
+        val durationString = arguments[1]
+        val reason = arguments[2]
+
+        val target = resolveTargetAccount(arguments[0], player) ?: return
+        val duration = Duration.parse(durationString)
+
+        database!!.punishment().ban(target, issuer, reason, currentServer(), duration.toJavaDuration())
+        player.sendMessage("${target.username} was banned.")
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Ban.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Ban.kt
@@ -2,11 +2,8 @@ package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
 import mindustry.gen.Player
-import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
 import net.ddns.mindustry.database.plugin.currentServer
-import net.ddns.mindustry.database.plugin.resolveTargetAccount
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
@@ -25,25 +22,11 @@ class Ban(handler: CommandHandler) : PrivilegedClientCommand(handler) {
     }
 
     override fun runner(arguments: Array<String>, player: Player) {
-        val issuerAccount = hasPermission(banPermission, player) ?: return
+        val (issuer, target) = preparePunishment(arguments, player, banPermission, "ban", 3,
+            "[scarlet]Usage: /ban <account-name> <duration> <reason...>  (or /ban with no arguments to pick from a menu)") ?: return
 
-        if (arguments.isEmpty()) {
-            PunishFlow.start(player, "ban")
-            return
-        }
-        if (arguments.size < 3) {
-            player.sendMessage("[scarlet]Usage: /ban <account-name> <duration> <reason...>  (or /ban with no arguments to pick from a menu)")
-            return
-        }
-
-        val issuer = Issuer.Player(issuerAccount)
-        val durationString = arguments[1]
-        val reason = arguments[2]
-
-        val target = resolveTargetAccount(arguments[0], player) ?: return
-        val duration = Duration.parse(durationString)
-
-        database!!.punishment().ban(target, issuer, reason, currentServer(), duration.toJavaDuration())
+        val duration = Duration.parse(arguments[1]).toJavaDuration()
+        database!!.punishment().ban(target, issuer, arguments[2], currentServer(), duration)
         player.sendMessage("${target.username} was banned.")
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Kick.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Kick.kt
@@ -2,11 +2,8 @@ package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
 import mindustry.gen.Player
-import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
 import net.ddns.mindustry.database.plugin.currentServer
-import net.ddns.mindustry.database.plugin.resolveTargetAccount
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 
 class Kick(handler: CommandHandler) : PrivilegedClientCommand(handler) {
@@ -24,23 +21,10 @@ class Kick(handler: CommandHandler) : PrivilegedClientCommand(handler) {
     }
 
     override fun runner(arguments: Array<String>, player: Player) {
-        val issuerAccount = hasPermission(permission, player) ?: return
+        val (issuer, target) = preparePunishment(arguments, player, permission, PERMISSION_NAME, 2,
+            "[scarlet]Usage: /kick <account-name> <reason...>  (or /kick with no arguments to pick from a menu)") ?: return
 
-        if (arguments.isEmpty()) {
-            PunishFlow.start(player, PERMISSION_NAME)
-            return
-        }
-        if (arguments.size < 2) {
-            player.sendMessage("[scarlet]Usage: /kick <account-name> <reason...>  (or /kick with no arguments to pick from a menu)")
-            return
-        }
-
-        val issuer = Issuer.Player(issuerAccount)
-        val reason = arguments[1]
-
-        val target = resolveTargetAccount(arguments[0], player) ?: return
-
-        database!!.punishment().kick(target, issuer, reason, currentServer())
+        database!!.punishment().kick(target, issuer, arguments[1], currentServer())
         player.sendMessage("${target.username} was kicked.")
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Kick.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Kick.kt
@@ -2,10 +2,11 @@ package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
 import mindustry.gen.Player
-import mindustry.net.Administration
 import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.database.plugin.configs.PluginConfigs
+import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
+import net.ddns.mindustry.database.plugin.currentServer
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 
 class Kick(handler: CommandHandler) : PrivilegedClientCommand(handler) {
@@ -14,8 +15,8 @@ class Kick(handler: CommandHandler) : PrivilegedClientCommand(handler) {
         private const val PERMISSION_NAME = "kick"
 
         init {
-            description = "Kicks a player."
-            parameters = "<account-name> <reason...>"
+            description = "Kicks a player by account name, or run with no arguments to pick an online player from a menu."
+            parameters = "[account-name] [reason...]"
 
             database!!.role().newPermission(PERMISSION_NAME)
             permission = database!!.role().findPermission(PERMISSION_NAME).get()
@@ -24,20 +25,22 @@ class Kick(handler: CommandHandler) : PrivilegedClientCommand(handler) {
 
     override fun runner(arguments: Array<String>, player: Player) {
         val issuerAccount = hasPermission(permission, player) ?: return
-        val issuer = Issuer.Player(issuerAccount)
 
-        val targetName = arguments[0]
-        val reason = arguments[1]
-
-        val target = database!!.account().find(targetName)
-        val server = database!!.server().find(PluginConfigs.configServerIP.string(), Administration.Config.port.num())
-
-        if (target.isEmpty) {
-            player.sendMessage("[scarlet]Couldn't find that player!")
+        if (arguments.isEmpty()) {
+            PunishFlow.start(player, PERMISSION_NAME)
+            return
+        }
+        if (arguments.size < 2) {
+            player.sendMessage("[scarlet]Usage: /kick <account-name> <reason...>  (or /kick with no arguments to pick from a menu)")
             return
         }
 
-        database!!.punishment().kick(target.get(), issuer, reason, server.get())
-        player.sendMessage("$targetName was kicked.")
+        val issuer = Issuer.Player(issuerAccount)
+        val reason = arguments[1]
+
+        val target = resolveTargetAccount(arguments[0], player) ?: return
+
+        database!!.punishment().kick(target, issuer, reason, currentServer())
+        player.sendMessage("${target.username} was kicked.")
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/LookupBans.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/LookupBans.kt
@@ -5,6 +5,9 @@ import arc.util.Log
 import mindustry.gen.Player
 import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
+import net.ddns.mindustry.database.plugin.PlayerSelect
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
+import net.ddns.mindustry.database.schema.tables.pojos.Account
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 
 class LookupBans(handler: CommandHandler) : PrivilegedClientCommand(handler) {
@@ -13,8 +16,9 @@ class LookupBans(handler: CommandHandler) : PrivilegedClientCommand(handler) {
         private const val PERMISSION_NAME = "ban"
 
         init {
-            description = "Looks up the active bans that a player has."
-            parameters = "<account-name>"
+            description = "Looks up the active bans a player has, by account name, or run with no arguments to " +
+                    "pick an online player from a menu."
+            parameters = "[account-name]"
 
             database!!.role().newPermission(PERMISSION_NAME)
             permission = database!!.role().findPermission(PERMISSION_NAME).get()
@@ -22,17 +26,21 @@ class LookupBans(handler: CommandHandler) : PrivilegedClientCommand(handler) {
     }
 
     override fun runner(arguments: Array<String>, player: Player) {
-        val account = hasPermission(permission, player) ?: return
-        val targetName = arguments[0]
+        hasPermission(permission, player) ?: return
 
-        val target = database!!.account().find(targetName)
-
-        if (target.isEmpty) {
-            player.sendMessage("[scarlet]Couldn't find that player!")
+        if (arguments.isEmpty()) {
+            PlayerSelect.open(player, title = "[gold]Look up bans", message = "Select a player.") { account ->
+                showBans(account, player)
+            }
             return
         }
 
-        val bans = database!!.punishment().activeBans(target.get())
+        val target = resolveTargetAccount(arguments[0], player) ?: return
+        showBans(target, player)
+    }
+
+    private fun showBans(target: Account, player: Player) {
+        val bans = database!!.punishment().activeBans(target)
 
         if (bans.size == 0) {
             player.sendMessage("That player has no active bans.")

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/PrivilegedClientCommand.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/PrivilegedClientCommand.kt
@@ -1,6 +1,38 @@
 package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
+import mindustry.gen.Player
+import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.commands.client.BaseClientCommand
+import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
+import net.ddns.mindustry.database.schema.tables.pojos.Account
+import net.ddns.mindustry.database.schema.tables.pojos.Permission
 
 sealed class PrivilegedClientCommand(handler: CommandHandler) : BaseClientCommand(handler)
+
+/**
+ * The shared front half of the text punishment commands (`/ban`, `/kick`, `/warn`): permission check
+ */
+fun PrivilegedClientCommand.preparePunishment(
+    arguments: Array<String>,
+    player: Player,
+    permission: Permission,
+    type: String,
+    minArgs: Int,
+    usage: String,
+): Pair<Issuer, Account>? {
+    val issuerAccount = hasPermission(permission, player) ?: return null
+
+    if (arguments.isEmpty()) {
+        PunishFlow.start(player, type)
+        return null
+    }
+    if (arguments.size < minArgs) {
+        player.sendMessage(usage)
+        return null
+    }
+
+    val target = resolveTargetAccount(arguments[0], player) ?: return null
+    return Issuer.Player(issuerAccount) to target
+}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/PrivilegedClientCommand.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/PrivilegedClientCommand.kt
@@ -19,7 +19,7 @@ fun PrivilegedClientCommand.preparePunishment(
     player: Player,
     permission: Permission,
     type: String,
-    minArgs: Int,
+    expectedArgs: Int,
     usage: String,
 ): Pair<Issuer, Account>? {
     val issuerAccount = hasPermission(permission, player) ?: return null
@@ -28,7 +28,7 @@ fun PrivilegedClientCommand.preparePunishment(
         PunishFlow.start(player, type)
         return null
     }
-    if (arguments.size < minArgs) {
+    if (arguments.size != expectedArgs) {
         player.sendMessage(usage)
         return null
     }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Warn.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Warn.kt
@@ -2,11 +2,8 @@ package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
 import mindustry.gen.Player
-import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
 import net.ddns.mindustry.database.plugin.currentServer
-import net.ddns.mindustry.database.plugin.resolveTargetAccount
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 
 class Warn(handler: CommandHandler) : PrivilegedClientCommand(handler) {
@@ -24,23 +21,10 @@ class Warn(handler: CommandHandler) : PrivilegedClientCommand(handler) {
     }
 
     override fun runner(arguments: Array<String>, player: Player) {
-        val issuerAccount = hasPermission(permission, player) ?: return
+        val (issuer, target) = preparePunishment(arguments, player, permission, PERMISSION_NAME, 2,
+            "[scarlet]Usage: /warn <account-name> <reason...>  (or /warn with no arguments to pick from a menu)") ?: return
 
-        if (arguments.isEmpty()) {
-            PunishFlow.start(player, PERMISSION_NAME)
-            return
-        }
-        if (arguments.size < 2) {
-            player.sendMessage("[scarlet]Usage: /warn <account-name> <reason...>  (or /warn with no arguments to pick from a menu)")
-            return
-        }
-
-        val issuer = Issuer.Player(issuerAccount)
-        val reason = arguments[1]
-
-        val target = resolveTargetAccount(arguments[0], player) ?: return
-
-        database!!.punishment().warn(target, issuer, reason, currentServer())
+        database!!.punishment().warn(target, issuer, arguments[1], currentServer())
         player.sendMessage("${target.username} was warned.")
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Warn.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/Warn.kt
@@ -2,10 +2,11 @@ package net.ddns.mindustry.database.plugin.commands.client.privileged
 
 import arc.util.CommandHandler
 import mindustry.gen.Player
-import mindustry.net.Administration
 import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.database.plugin.configs.PluginConfigs
+import net.ddns.mindustry.database.plugin.commands.client.privileged.ui.PunishFlow
+import net.ddns.mindustry.database.plugin.currentServer
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
 import net.ddns.mindustry.database.schema.tables.pojos.Permission
 
 class Warn(handler: CommandHandler) : PrivilegedClientCommand(handler) {
@@ -14,8 +15,8 @@ class Warn(handler: CommandHandler) : PrivilegedClientCommand(handler) {
         private const val PERMISSION_NAME = "warn"
 
         init {
-            description = "Warns a player."
-            parameters = "<account-name> <reason...>"
+            description = "Warns a player by account name, or run with no arguments to pick an online player from a menu."
+            parameters = "[account-name] [reason...]"
 
             database!!.role().newPermission(PERMISSION_NAME)
             permission = database!!.role().findPermission(PERMISSION_NAME).get()
@@ -24,20 +25,22 @@ class Warn(handler: CommandHandler) : PrivilegedClientCommand(handler) {
 
     override fun runner(arguments: Array<String>, player: Player) {
         val issuerAccount = hasPermission(permission, player) ?: return
-        val issuer = Issuer.Player(issuerAccount)
 
-        val targetName = arguments[0]
-        val reason = arguments[1]
-
-        val target = database!!.account().find(targetName)
-        val server = database!!.server().find(PluginConfigs.configServerIP.string(), Administration.Config.port.num())
-
-        if (target.isEmpty) {
-            player.sendMessage("[scarlet]Couldn't find that player!")
+        if (arguments.isEmpty()) {
+            PunishFlow.start(player, PERMISSION_NAME)
+            return
+        }
+        if (arguments.size < 2) {
+            player.sendMessage("[scarlet]Usage: /warn <account-name> <reason...>  (or /warn with no arguments to pick from a menu)")
             return
         }
 
-        database!!.punishment().warn(target.get(), issuer, reason, server.get())
-        player.sendMessage("$targetName was warned.")
+        val issuer = Issuer.Player(issuerAccount)
+        val reason = arguments[1]
+
+        val target = resolveTargetAccount(arguments[0], player) ?: return
+
+        database!!.punishment().warn(target, issuer, reason, currentServer())
+        player.sendMessage("${target.username} was warned.")
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/Punish.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/Punish.kt
@@ -1,202 +1,31 @@
 package net.ddns.mindustry.database.plugin.commands.client.privileged.ui
 
 import arc.util.CommandHandler
-import arc.util.Log
-import mindustry.gen.Call
-import mindustry.gen.Groups
 import mindustry.gen.Player
-import net.ddns.mindustry.database.plugin.Main.Companion.database
-import net.ddns.mindustry.segment.menuHandler
-import net.ddns.mindustry.segment.textInputHandler
-import net.ddns.mindustry.segment.ui.Child
-import net.ddns.mindustry.segment.ui.menu.BaseMenu
-import net.ddns.mindustry.segment.ui.textInput.BaseTextInput
-import kotlin.time.Duration
-import kotlin.collections.getOrDefault
-import kotlin.time.toJavaDuration
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
 
+/**
+ * Opens the interactive punishment menu. The whole flow (action -> player -> reason -> duration -> execute) lives in
+ * [PunishFlow], which is shared with the no-argument forms of `/ban`, `/kick` and `/warn`.
+ *
+ * With no argument it opens the online-player picker; given an account name it acts on that account directly, which
+ * also works for offline players.
+ */
 class Punish(handler: CommandHandler) : PrivilegedUiClientCommand(handler) {
-    val optionsMenu = menuHandler.addMenu("[gold]Punish UI", "Select an action.", punishOptions, ::typeSelected, true)
-    var playerMenu: BaseMenu? = null
-    val reasonInput = textInputHandler.addTextInput("[gold]Punish UI", "Why are you taking action against this person?",
-        ::reasonGiven, 200, persist=true) // 200 too much?
-    val durationInput = textInputHandler.addTextInput("[gold]Punish UI", "How long should the ban last? (ex: 365d)",
-        ::gotDuration, 5, persist=true) // any more than 5 is absurd.
-
     companion object {
-//        val banPermission: Permission
-        val punishmentBuilders: MutableMap<Player, PunishmentBuilder> = mutableMapOf()
-        val punishOptions = arrayOf(arrayOf("Ban", "Kick", "Warn"))
-
         init {
-            description = "Punish a player via UI."
-            parameters = ""
-
-//            database!!.role().newPermission("ban")
-//            banPermission = database!!.role().findPermission("ban").get()
+            description = "Punish a player via an interactive menu. Pass an account name to act on an offline player."
+            parameters = "[account-name]"
         }
-    }
-
-    fun confirmPermissions(player: Player): Boolean {
-        var score = 0   // player needs at least one permission to run the command; if score is non-zero, then they can
-                        // run the command.
-
-        for (punishment in punishOptions[0]) {
-            val permission = database!!.role().findPermission(punishment.lowercase())
-            if (permission.isEmpty) {
-                Log.err("Couldn't find permission for @.", punishment.lowercase())
-                player.sendMessage("[scarlet]Couldn't confirm your permissions.")
-                return false
-            }
-
-            if (hasPermission(permission.get(), player) != null) { score += 1 }
-        }
-
-        return score != 0
-    }
-
-    fun typeError(player: Player, expected: String = "BaseMenu") {
-        player.sendMessage("[scarlet]A fatal error occurred.")
-        Log.err("Menu callback expected @ for child type, but got a different type instead.", expected)
-    }
-
-    fun retrieveBuilder(player: Player): PunishmentBuilder? {
-        val builder = punishmentBuilders.getOrDefault(player, null)
-        if (builder == null) {
-            player.sendMessage("[scarlet]Couldn't retrieve the punishment builder.")
-            Log.err("Couldn't retrieve the punishment builder for @ / @.", player.plainName(), player.uuid())
-        }
-
-        return builder
     }
 
     override fun runner(arguments: Array<String>, player: Player) {
-        if (!confirmPermissions(player)) { return }
-
-        optionsMenu.show(player.con())
-    }
-
-    fun typeSelected(player: Player, child: Child) {
-        if (child !is BaseMenu) {
-            typeError(player)
-            return
-        }
-        else if (child.option >= punishOptions[0].size) { return }
-        else if (child.option == -1) { return }
-
-        val punishmentType = punishOptions[0][child.option].lowercase();
-        val permission = database!!.role().findPermission(punishmentType)
-        if (permission.isEmpty) {
-            Log.err("Couldn't find permission for @.", punishmentType)
-            player.sendMessage("[scarlet]Couldn't confirm your permissions.")
-            return;
-        }
-        if (hasPermission(permission.get(), player) == null) {
-            optionsMenu.show(player.con())
+        if (arguments.isEmpty()) {
+            PunishFlow.start(player)
             return
         }
 
-        val builder = PunishmentBuilder(optionsMenu.id, player)
-        builder.punishmentType = punishmentType
-        punishmentBuilders[player] = builder
-
-        val usernameList = mutableListOf<Array<String>>()
-        for (username in builder.players) {
-            usernameList.addFirst(arrayOf(username.value))
-        }
-
-        playerMenu = menuHandler.addMenu("[gold]Punish UI", "Select a player.", usernameList.toTypedArray(),
-            ::playerSelected, false)
-//        playerMenu!!.id = builder.menuId
-        playerMenu!!.show(player.con())
-    }
-
-    fun playerSelected(player: Player, child: Child) {
-        if (child !is BaseMenu) {
-            typeError(player)
-            return
-        }
-        else if (child.option == -1) { return }
-
-        val builder = retrieveBuilder(player) ?: return
-        if (child.option >= builder.players.size) { return }
-
-        val playerArray = builder.players.keys.toTypedArray()
-        playerArray.reverse()
-
-        val target = child.option
-        val targetPlayer = playerArray.getOrNull(target)
-        if (targetPlayer == null) {
-            player.sendMessage("[scarlet]Couldn't find the specified player!")
-            Log.err("Couldn't find target player for @ / @.", player.plainName(), player.uuid())
-            return
-        }
-
-        val targetAccount = database!!.account().find(targetPlayer.ip(), targetPlayer.uuid())
-        if (targetAccount.isEmpty) {
-            player.sendMessage("[scarlet]Couldn't find an account for that player! Are they logged in?")
-            return
-        }
-        builder.target = targetAccount.get()
-
-        reasonInput.show(player.con())
-    }
-
-    fun reasonGiven(player: Player, child: Child) {
-        if (child !is BaseTextInput) {
-            typeError(player, "BaseTextInput")
-            return
-        }
-        else if (child.text.isNullOrEmpty()) {
-            if (child.text != null) {
-                Call.infoMessage("[yellow]Cannot have an empty reason.")
-                reasonInput.show()
-            }
-            return
-        }
-
-        val builder = retrieveBuilder(player) ?: return
-        builder.reason = child.text
-
-        if (builder.punishmentType.isNullOrEmpty()) {
-            player.sendMessage("[scarlet]Punishment type was empty.")
-            Log.err("Punishment type was empty for @ / @.", player.plainName(), player.uuid())
-            return
-        }
-
-        if (builder.punishmentType!!.lowercase() == "ban") {
-            durationInput.show(player.con())
-            return
-        }
-
-        builder.execute()
-    }
-
-    fun gotDuration(player: Player, child: Child) {
-        if (child !is BaseTextInput) {
-            typeError(player, "BaseTextInput")
-            return
-        }
-        else if (child.text.isNullOrEmpty()) {
-            if (child.text != null) {
-                Call.infoMessage("[yellow]Cannot have an empty duration.")
-                reasonInput.show()
-            }
-            return
-        }
-
-        val builder = retrieveBuilder(player) ?: return
-
-        val duration: Duration
-        try {
-            duration = Duration.parse(child.text!!)
-        } catch (_: IllegalArgumentException) {
-            Call.infoMessage(player.con(), "[scarlet]Must have a valid duration.")
-            durationInput.show()
-            return
-        }
-
-        builder.duration = duration.toJavaDuration()
-        builder.execute()
+        val target = resolveTargetAccount(arguments[0], player) ?: return
+        PunishFlow.start(player, presetTarget = target)
     }
 }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishFlow.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishFlow.kt
@@ -1,0 +1,158 @@
+package net.ddns.mindustry.database.plugin.commands.client.privileged.ui
+
+import arc.util.Log
+import mindustry.gen.Call
+import mindustry.gen.Player
+import net.ddns.mindustry.database.plugin.Main.Companion.database
+import net.ddns.mindustry.database.plugin.PlayerSelect
+import net.ddns.mindustry.database.schema.tables.pojos.Account
+import net.ddns.mindustry.segment.menuHandler
+import net.ddns.mindustry.segment.textInputHandler
+import net.ddns.mindustry.segment.ui.Child
+import net.ddns.mindustry.segment.ui.menu.BaseMenu
+import net.ddns.mindustry.segment.ui.textInput.BaseTextInput
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+/**
+ * The shared interactive "punish a player" flow: action -> player -> reason -> (duration) -> execute.
+ *
+ * [start] seeds whatever is already known and [proceed] drives the rest, prompting only for the missing pieces:
+ *  - `/punish` (no arguments): nothing known -> action menu -> player picker -> reason ...
+ *  - `/ban`, `/kick`, `/warn` (no arguments): action known -> player picker -> reason ...
+ *  - `/punish <account-name>`: target known (and may be offline) -> action menu -> reason ... (the picker is skipped).
+ *
+ * The menus and text inputs are registered once, lazily, on first use.
+ */
+object PunishFlow {
+
+    private val actionOptions = arrayOf(arrayOf("Ban", "Kick", "Warn"))
+    private val builders: MutableMap<Player, PunishmentBuilder> = mutableMapOf()
+
+    private var actionMenu: BaseMenu? = null
+    private var reasonInput: BaseTextInput? = null
+    private var durationInput: BaseTextInput? = null
+
+    private fun ensureRegistered() {
+        if (actionMenu != null) return
+
+        actionMenu = menuHandler.addMenu("[gold]Punish UI", "Select an action.", actionOptions, ::actionSelected, true)
+        reasonInput = textInputHandler.addTextInput(
+            "[gold]Punish UI", "Why are you taking action against this person?", ::reasonGiven, 200, persist = true)
+        durationInput = textInputHandler.addTextInput(
+            "[gold]Punish UI", "How long should the ban last? (ex: 365d)", ::gotDuration, 5, persist = true)
+    }
+
+    /**
+     * Starts the flow for [staff], pre-filling the [presetType] ("ban"/"kick"/"warn") and/or [presetTarget] when the
+     * caller already knows them. Anything left null is prompted for interactively.
+     */
+    fun start(staff: Player, presetType: String? = null, presetTarget: Account? = null) {
+        ensureRegistered()
+
+        val allowed = if (presetType != null) hasPermission(staff, presetType.lowercase())
+                      else actionOptions[0].any { hasPermission(staff, it.lowercase()) }
+        if (!allowed) {
+            staff.sendMessage("[scarlet]You do not have permission to run this command.")
+            return
+        }
+
+        builders[staff] = PunishmentBuilder(staff).apply {
+            punishmentType = presetType?.lowercase()
+            target = presetTarget
+        }
+        proceed(staff)
+    }
+
+    /** Advances the flow, prompting for whichever piece is still missing. */
+    private fun proceed(staff: Player) {
+        val builder = builders[staff] ?: return
+
+        when {
+            builder.punishmentType == null -> actionMenu!!.show(staff.con())
+            builder.target == null -> selectPlayer(staff)
+            else -> reasonInput!!.show(staff.con())
+        }
+    }
+
+    private fun actionSelected(staff: Player, child: Child) {
+        if (child !is BaseMenu || child.option !in actionOptions[0].indices) return
+
+        val type = actionOptions[0][child.option].lowercase()
+        if (!hasPermission(staff, type)) {
+            actionMenu!!.show(staff.con())
+            return
+        }
+
+        val builder = builders[staff] ?: return
+        builder.punishmentType = type
+        proceed(staff)
+    }
+
+    private fun selectPlayer(staff: Player) {
+        PlayerSelect.open(staff, title = "[gold]Punish UI", message = "Select a player.") { account ->
+            val builder = builders[staff] ?: return@open
+            builder.target = account
+            proceed(staff)
+        }
+    }
+
+    private fun reasonGiven(staff: Player, child: Child) {
+        if (child !is BaseTextInput) return
+        if (child.text.isNullOrEmpty()) {
+            if (child.text != null) {
+                Call.infoMessage(staff.con(), "[yellow]Cannot have an empty reason.")
+                reasonInput!!.show(staff.con())
+            }
+            return
+        }
+
+        val builder = builders[staff] ?: return
+        builder.reason = child.text
+
+        if (builder.punishmentType == "ban") {
+            durationInput!!.show(staff.con())
+            return
+        }
+
+        builder.execute()
+        builders.remove(staff)
+    }
+
+    private fun gotDuration(staff: Player, child: Child) {
+        if (child !is BaseTextInput) return
+        if (child.text.isNullOrEmpty()) {
+            if (child.text != null) {
+                Call.infoMessage(staff.con(), "[yellow]Cannot have an empty duration.")
+                durationInput!!.show(staff.con())
+            }
+            return
+        }
+
+        val builder = builders[staff] ?: return
+        val duration = try {
+            Duration.parse(child.text!!)
+        } catch (_: IllegalArgumentException) {
+            Call.infoMessage(staff.con(), "[scarlet]Must have a valid duration.")
+            durationInput!!.show(staff.con())
+            return
+        }
+
+        builder.duration = duration.toJavaDuration()
+        builder.execute()
+        builders.remove(staff)
+    }
+
+    /** Quiet permission check (no player messages) so the "any of" gate at entry doesn't spam denials. */
+    private fun hasPermission(staff: Player, permissionName: String): Boolean {
+        val account = database!!.account().find(staff.ip(), staff.uuid())
+        if (account.isEmpty) return false
+
+        val permission = database!!.role().findPermission(permissionName)
+        if (permission.isEmpty) {
+            Log.err("Couldn't find permission for @.", permissionName)
+            return false
+        }
+        return database!!.role().hasPermissions(account.get(), permission.get())
+    }
+}

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishFlow.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishFlow.kt
@@ -98,17 +98,10 @@ object PunishFlow {
     }
 
     private fun reasonGiven(staff: Player, child: Child) {
-        if (child !is BaseTextInput) return
-        if (child.text.isNullOrEmpty()) {
-            if (child.text != null) {
-                Call.infoMessage(staff.con(), "[yellow]Cannot have an empty reason.")
-                reasonInput!!.show(staff.con())
-            }
-            return
-        }
+        val reason = requireText(staff, child, reasonInput!!, "[yellow]Cannot have an empty reason.") ?: return
 
         val builder = builders[staff] ?: return
-        builder.reason = child.text
+        builder.reason = reason
 
         if (builder.punishmentType == "ban") {
             durationInput!!.show(staff.con())
@@ -120,18 +113,11 @@ object PunishFlow {
     }
 
     private fun gotDuration(staff: Player, child: Child) {
-        if (child !is BaseTextInput) return
-        if (child.text.isNullOrEmpty()) {
-            if (child.text != null) {
-                Call.infoMessage(staff.con(), "[yellow]Cannot have an empty duration.")
-                durationInput!!.show(staff.con())
-            }
-            return
-        }
+        val text = requireText(staff, child, durationInput!!, "[yellow]Cannot have an empty duration.") ?: return
 
         val builder = builders[staff] ?: return
         val duration = try {
-            Duration.parse(child.text!!)
+            Duration.parse(text)
         } catch (_: IllegalArgumentException) {
             Call.infoMessage(staff.con(), "[scarlet]Must have a valid duration.")
             durationInput!!.show(staff.con())
@@ -141,6 +127,21 @@ object PunishFlow {
         builder.duration = duration.toJavaDuration()
         builder.execute()
         builders.remove(staff)
+    }
+
+    /** Reads the submitted text, re-prompting (with [emptyMessage]) when it's blank. Returns null if not yet given. */
+    private fun requireText(staff: Player, child: Child, input: BaseTextInput, emptyMessage: String): String? {
+        if (child !is BaseTextInput) return null
+
+        val text = child.text
+        if (text.isNullOrEmpty()) {
+            if (text != null) {
+                Call.infoMessage(staff.con(), emptyMessage)
+                input.show(staff.con())
+            }
+            return null
+        }
+        return text
     }
 
     /** Quiet permission check (no player messages) so the "any of" gate at entry doesn't spam denials. */

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishFlow.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishFlow.kt
@@ -29,17 +29,15 @@ object PunishFlow {
     private val actionOptions = arrayOf(arrayOf("Ban", "Kick", "Warn"))
     private val builders: MutableMap<Player, PunishmentBuilder> = mutableMapOf()
 
-    private var actionMenu: BaseMenu? = null
-    private var reasonInput: BaseTextInput? = null
-    private var durationInput: BaseTextInput? = null
-
-    private fun ensureRegistered() {
-        if (actionMenu != null) return
-
-        actionMenu = menuHandler.addMenu("[gold]Punish UI", "Select an action.", actionOptions, ::actionSelected, true)
-        reasonInput = textInputHandler.addTextInput(
+    private val actionMenu: BaseMenu by lazy {
+        menuHandler.addMenu("[gold]Punish UI", "Select an action.", actionOptions, ::actionSelected, true)
+    }
+    private val reasonInput: BaseTextInput by lazy {
+        textInputHandler.addTextInput(
             "[gold]Punish UI", "Why are you taking action against this person?", ::reasonGiven, 200, persist = true)
-        durationInput = textInputHandler.addTextInput(
+    }
+    private val durationInput: BaseTextInput by lazy {
+        textInputHandler.addTextInput(
             "[gold]Punish UI", "How long should the ban last? (ex: 365d)", ::gotDuration, 5, persist = true)
     }
 
@@ -48,8 +46,6 @@ object PunishFlow {
      * caller already knows them. Anything left null is prompted for interactively.
      */
     fun start(staff: Player, presetType: String? = null, presetTarget: Account? = null) {
-        ensureRegistered()
-
         val allowed = if (presetType != null) hasPermission(staff, presetType.lowercase())
                       else actionOptions[0].any { hasPermission(staff, it.lowercase()) }
         if (!allowed) {
@@ -69,9 +65,9 @@ object PunishFlow {
         val builder = builders[staff] ?: return
 
         when {
-            builder.punishmentType == null -> actionMenu!!.show(staff.con())
+            builder.punishmentType == null -> actionMenu.show(staff.con())
             builder.target == null -> selectPlayer(staff)
-            else -> reasonInput!!.show(staff.con())
+            else -> reasonInput.show(staff.con())
         }
     }
 
@@ -80,7 +76,7 @@ object PunishFlow {
 
         val type = actionOptions[0][child.option].lowercase()
         if (!hasPermission(staff, type)) {
-            actionMenu!!.show(staff.con())
+            actionMenu.show(staff.con())
             return
         }
 
@@ -98,13 +94,13 @@ object PunishFlow {
     }
 
     private fun reasonGiven(staff: Player, child: Child) {
-        val reason = requireText(staff, child, reasonInput!!, "[yellow]Cannot have an empty reason.") ?: return
+        val reason = requireText(staff, child, reasonInput, "[yellow]Cannot have an empty reason.") ?: return
 
         val builder = builders[staff] ?: return
         builder.reason = reason
 
         if (builder.punishmentType == "ban") {
-            durationInput!!.show(staff.con())
+            durationInput.show(staff.con())
             return
         }
 
@@ -113,14 +109,14 @@ object PunishFlow {
     }
 
     private fun gotDuration(staff: Player, child: Child) {
-        val text = requireText(staff, child, durationInput!!, "[yellow]Cannot have an empty duration.") ?: return
+        val text = requireText(staff, child, durationInput, "[yellow]Cannot have an empty duration.") ?: return
 
         val builder = builders[staff] ?: return
         val duration = try {
             Duration.parse(text)
         } catch (_: IllegalArgumentException) {
             Call.infoMessage(staff.con(), "[scarlet]Must have a valid duration.")
-            durationInput!!.show(staff.con())
+            durationInput.show(staff.con())
             return
         }
 

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishmentBuilder.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/privileged/ui/PunishmentBuilder.kt
@@ -1,25 +1,20 @@
 package net.ddns.mindustry.database.plugin.commands.client.privileged.ui
 
 import arc.util.Log
-import mindustry.gen.Groups
 import mindustry.gen.Player
-import mindustry.net.Administration
 import net.ddns.mindustry.database.client.PunishmentQueries.Issuer
 import net.ddns.mindustry.database.plugin.Main.Companion.database
 import net.ddns.mindustry.database.plugin.commands.client.BaseClientCommand.Companion.playerHasPermission
-import net.ddns.mindustry.database.plugin.commands.client.playerToDisplayName
-import net.ddns.mindustry.database.plugin.configs.PluginConfigs
+import net.ddns.mindustry.database.plugin.currentServer
 import net.ddns.mindustry.database.schema.tables.pojos.Account
 import java.time.Duration
 
-class PunishmentBuilder(val menuId: Int, val author: Player) {
+class PunishmentBuilder(val author: Player) {
     var punishmentType: String? = null // although this isn't optimal, the likelihood of a player sending an invalid
                                         // option is unlikely.
     var target: Account? = null
     var reason: String? = null
     var duration: Duration? = null
-
-    val players: Map<Player, String> = mapPlayerNames()
 
     fun permissionCheck(name: String): Account? {
         val permission = database!!.role().findPermission(name)
@@ -31,20 +26,8 @@ class PunishmentBuilder(val menuId: Int, val author: Player) {
         return issuer
     }
 
-    private fun mapPlayerNames(): MutableMap<Player, String> {
-        val names = mutableMapOf<Player, String>()
-
-        Groups.player.forEach { player ->
-            if (!player.plainName().isEmpty()) {
-                names[player] = player.coloredName()
-            }
-        }
-
-        return names
-    }
-
     fun execute() {
-        val server = database!!.server().find(PluginConfigs.configServerIP.string(), Administration.Config.port.num())
+        val server = currentServer()
 
         if (listOf(target, reason, punishmentType).contains(null)) {
             author.sendMessage("[scarlet]How did you mess up this badly? Just talk to Lett at this point.")
@@ -60,11 +43,11 @@ class PunishmentBuilder(val menuId: Int, val author: Player) {
         when (punishmentType) {
             "warn" -> {
                 val issuer = permissionCheck("warn")
-                database!!.punishment().warn(target, Issuer.Player(issuer), reason, server.get())
+                database!!.punishment().warn(target, Issuer.Player(issuer), reason, server)
             }
             "kick" -> {
                 val issuer = permissionCheck("kick")
-                database!!.punishment().kick(target, Issuer.Player(issuer), reason, server.get())
+                database!!.punishment().kick(target, Issuer.Player(issuer), reason, server)
             }
             "ban" -> {
                 if (duration == null) {
@@ -74,7 +57,7 @@ class PunishmentBuilder(val menuId: Int, val author: Player) {
                 }
 
                 val issuer = permissionCheck("ban")
-                database!!.punishment().ban(target, Issuer.Player(issuer), reason, server.get(), duration)
+                database!!.punishment().ban(target, Issuer.Player(issuer), reason, server, duration)
             }
         }
     }

--- a/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/unprivileged/History.kt
+++ b/plugin/src/main/kotlin/net/ddns/mindustry/database/plugin/commands/client/unprivileged/History.kt
@@ -3,8 +3,10 @@ package net.ddns.mindustry.database.plugin.commands.client.unprivileged
 import arc.util.CommandHandler
 import mindustry.Vars
 import mindustry.gen.Player
+import net.ddns.mindustry.database.plugin.PlayerSelect
 import net.ddns.mindustry.database.plugin.renderPlayerHistory
 import net.ddns.mindustry.database.plugin.renderTileHistory
+import net.ddns.mindustry.database.plugin.resolveTargetAccount
 
 /**
  * Lets any player inspect what changed and by whom.
@@ -22,7 +24,8 @@ class History(handler: CommandHandler) : UnprivilegedClientCommand(handler) {
             description = "Inspect who changed a tile or what a player did. " +
                     "[lightgray](in-memory, resets on map change)[]\n" +
                     "  [accent]/history[white] - toggle tap-to-inspect, then tap a tile\n" +
-                    "  [accent]/history <player>[white] - that player's recent actions\n" +
+                    "  [accent]/history <player>[white] - that player's recent actions (by account name)\n" +
+                    "  [accent]/history pick[white] - pick an online player from a menu\n" +
                     "  [accent]/history <x> <y>[white] - history of a single tile"
             parameters = "[player/x] [y]"
         }
@@ -31,9 +34,22 @@ class History(handler: CommandHandler) : UnprivilegedClientCommand(handler) {
     override fun runner(arguments: Array<String>, player: Player) {
         when (arguments.size) {
             0 -> toggleInspect(player)
-            1 -> player.sendMessage(renderPlayerHistory(arguments[0]))
+            1 -> {
+                if (arguments[0].equals("pick", ignoreCase = true)) {
+                    pickPlayer(player)
+                    return
+                }
+                val target = resolveTargetAccount(arguments[0], player) ?: return
+                player.sendMessage(renderPlayerHistory(target.username))
+            }
             2 -> showTile(arguments[0], arguments[1], player)
             else -> player.sendMessage("[scarlet]Usage: /history, /history <player>, or /history <x> <y>")
+        }
+    }
+
+    private fun pickPlayer(player: Player) {
+        PlayerSelect.open(player, title = "[gold]Player history", message = "Select a player.") { account ->
+            player.sendMessage(renderPlayerHistory(account.username))
         }
     }
 


### PR DESCRIPTION
TLDR

Adds temp ID to each player's display name and a player picker for moderation commands.
Also makes /punish work on offline accounts and consolidates duplicated command/player logic.

Changes
  - In-game ID — on connect, each player is assigned a unique 2-char ID shown as an [A1] name prefix (freed on disconnect). 
  - Player picker (PlayerSelect): used by the punishment flow, /lookup-bans, and /history pick.
  - Shared punishment flow (PunishFlow) — extracted from /punish and reused by  /ban, /kick, /warn.
  - Offline /punish — /punish <account-name> acts on an account directly
  - Command UX — /ban, /kick, /warn, /lookup-bans, /history take a plain account name, otherwise picker

  Refactors / cleanup
  - currentServer() helper added (this can be done for rest of project)

  Notes
  - Less than 100 lines added (net), with ~60 for temp ids, ~20 for History taking Player Picker, and ~20 for the rest